### PR TITLE
chore: bump node image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # reference https://github.com/puppeteer/puppeteer/blob/main/docker/Dockerfile
-FROM node:20-slim
+FROM node:21-slim
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chrome that Puppeteer
@@ -18,6 +18,8 @@ RUN  apt-get update \
 
 # storage for node_modules
 RUN mkdir -p /app/node_modules
+
+ENV DBUS_SESSION_BUS_ADDRESS autolaunch:
 
 # /app as the default work directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ See the list of [Docker Hub tags](https://hub.docker.com/r/krsyoung/puppeteer/ta
 
 ## Releasing
 
-1. docker build --no-cache -t puppeteer:1.0.5 .
-2. docker tag puppeteer:1.0.5 krsyoung/puppeteer:1.0.5
-3. docker push krsyoung/puppeteer:1.0.5
+1. docker build --no-cache -t puppeteer:1.0.6 .
+2. docker tag puppeteer:1.0.6 krsyoung/puppeteer:1.0.6
+3. docker push krsyoung/puppeteer:1.0.6


### PR DESCRIPTION
Bump base image to node:21-slim.